### PR TITLE
First step to saving the gc information

### DIFF
--- a/dotnetInsights/package.json
+++ b/dotnetInsights/package.json
@@ -3,7 +3,7 @@
   "displayName": ".NET Insights",
   "publisher": "jashoo",
   "description": "Monitor .NET Processes for GC information in real time, or drill into .NET DLLs by viewing the IL and compiled code. Relies on ildasm and a public .NET JIT tool PMI.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "preview": false,
   "icon": "media/dep.png",
   "repository": {
@@ -30,6 +30,7 @@
     "onCommand:dotnetInsights.startGCMonitor",
     "onCustomEditor:dotnetInsights.edit",
     "onCustomEditor:dotnetInsightsGc.edit",
+    "onCustomEditor:dotnetInsightsGcSnapshot.edit",
     "onCommand:dotnetInsights.loadExtension",
     "onCommand:dotnetInsights.realtimeIl"
   ],
@@ -98,6 +99,11 @@
           "type": "boolean",
           "default": false,
           "description": "Turn off the verbose message that is given automatically on extension startup."
+        },
+        "dotnet-insights.gcDataPath": {
+          "type": "string",
+          "default": null,
+          "description": "Change default location for saving .gcinfo files."
         }
       }
     },
@@ -118,6 +124,16 @@
         "selector": [
           {
             "filenamePattern": "*.gcstats",
+            "priority": "default"
+          }
+        ]
+      },
+      {
+        "viewType": "dotnetInsightsGcSnapshot.edit",
+        "displayName": "Dotnet Insights GC Snapshot Editor",
+        "selector": [
+          {
+            "filenamePattern": "*.gcinfo",
             "priority": "default"
           }
         ]

--- a/dotnetInsights/src/DependencySetup.ts
+++ b/dotnetInsights/src/DependencySetup.ts
@@ -59,12 +59,15 @@ export class DependencySetup {
         var netcoreFiveCoreRootPath: any = undefined;
         var netcoreThreeCoreRootPath: any = undefined;
 
+        var gcStatsLocation: any = undefined;
+
         var outputPath: any = undefined;
 
         if (dotnetInsightsSettings != undefined) {
             ilDasmPath = dotnetInsightsSettings["ildasmPath"];
             pmiPath = dotnetInsightsSettings["pmiPath"];
             customCoreRootPath = dotnetInsightsSettings["coreRoot"];
+            gcStatsLocation = dotnetInsightsSettings["gcDataPath"];
             outputPath = dotnetInsightsSettings["outputPath"];
 
             gcEventListenerPath = dotnetInsightsSettings["gcEventListenerPath"];
@@ -76,6 +79,10 @@ export class DependencySetup {
 
             if (customCoreRootPath == undefined) {
                 customCoreRootPath = "";
+            }
+
+            if (gcStatsLocation == undefined) {
+                gcStatsLocation = "";
             }
         }
         else {
@@ -93,6 +100,19 @@ export class DependencySetup {
         if (!fs.existsSync(outputPath)) {
             // Create the folder
             fs.mkdirSync(outputPath);
+        }
+
+        if (gcStatsLocation == "") {
+            // Setup the gcData location. This will store all of the saved gc dumps
+            // with a .gcstats expension.
+
+            gcStatsLocation = path.join(outputPath, "gcInfo");
+
+            if (!fs.existsSync(gcStatsLocation)) {
+                fs.mkdirSync(gcStatsLocation);
+            }
+
+            this.insights.gcDataSaveLocation = gcStatsLocation;
         }
 
         var ilDasmOutputPath = path.join(outputPath, "ilDasm");

--- a/dotnetInsights/src/DotnetInsightsGcEditor.ts
+++ b/dotnetInsights/src/DotnetInsightsGcEditor.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as os from "os";
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -500,7 +501,7 @@ export class DotnetInsightsGcEditor implements vscode.CustomEditorProvider {
     }
 }
 
-class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextDocument {
+export class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextDocument {
     uri: vscode.Uri;
     fileName: string;
     isUntitled: boolean;
@@ -511,7 +512,7 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
     eol: vscode.EndOfLine;
     lineCount: number;
     processId: number;
-    listener: GcListener
+    listener: GcListener | null
 
     constructor(
         uri: vscode.Uri,
@@ -524,7 +525,7 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
         eol: vscode.EndOfLine,
         lineCount: number,
         processId: number,
-        listener: GcListener,
+        listener: GcListener | null,
     ) {
         super(() => {
             console.log("Tearing down ILDasmDocument");
@@ -585,7 +586,7 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
     saveCustomDocument(document: DotnetInsightsGcDocument, cancellation: any): Thenable<void>
     {
         var promise = new Promise<void>((resolve, reject) => {
-            const processInfo: ProcessInfo | undefined = this.listener.processes.get(document.processId);
+            const processInfo: ProcessInfo | undefined = this.listener?.processes.get(document.processId);
             const gcs: GcData[] | undefined = processInfo?.data;
             const allocations: AllocData[] | undefined = [];
 

--- a/dotnetInsights/src/DotnetInsightsGcEditor.ts
+++ b/dotnetInsights/src/DotnetInsightsGcEditor.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { DotnetInsights } from "./dotnetInsights";
 import { GcListener, ProcessInfo, GcData, AllocData } from "./GcListener";
 
-export class DotnetInsightsGcEditor implements vscode.CustomReadonlyEditorProvider {
+export class DotnetInsightsGcEditor implements vscode.CustomEditorProvider {
     public static register(context: vscode.ExtensionContext, insights: DotnetInsights, listener: GcListener): vscode.Disposable {
         const provider = new DotnetInsightsGcEditor(context, insights, listener, null);
         const providerRegistration = vscode.window.registerCustomEditorProvider(DotnetInsightsGcEditor.viewType, provider);
@@ -27,6 +27,17 @@ export class DotnetInsightsGcEditor implements vscode.CustomReadonlyEditorProvid
         this.allocData = undefined;
     }
 
+    onDidChangeCustomDocument() : any {
+
+    }
+
+    revertCustomDocument(document: vscode.CustomDocument, cancellation: vscode.CancellationToken): Thenable<void> {
+        throw new Error('Method not implemented.');
+    }
+    backupCustomDocument(document: vscode.CustomDocument, context: vscode.CustomDocumentBackupContext, cancellation: vscode.CancellationToken): Thenable<vscode.CustomDocumentBackup> {
+        throw new Error('Method not implemented.');
+    }
+
     openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext, token: vscode.CancellationToken): vscode.CustomDocument | Thenable<vscode.CustomDocument> {
         var filename = path.basename(uri.path);
         var endofLine = os.platform() == "win32" ? vscode.EndOfLine.CRLF : vscode.EndOfLine.LF;
@@ -42,7 +53,8 @@ export class DotnetInsightsGcEditor implements vscode.CustomReadonlyEditorProvid
                                                     true,
                                                     endofLine,
                                                     0,
-                                                    processId);
+                                                    processId,
+                                                    this.listener);
 
         return document;
     }
@@ -410,8 +422,83 @@ export class DotnetInsightsGcEditor implements vscode.CustomReadonlyEditorProvid
         }
         return text;
     }
-}
 
+    saveCustomDocument(document: DotnetInsightsGcDocument, cancellation: any): Thenable<void>
+    {
+        var promise = new Promise<void>((resolve, reject) => {
+            const processInfo: ProcessInfo | undefined = this.listener.processes.get(document.processId);
+            const gcs: GcData[] | undefined = processInfo?.data;
+            const allocations: AllocData[] | undefined = [];
+
+            var gcData = [] as GcData[];
+            if (gcs != undefined) {
+                for (var index = 0; index < gcs?.length; ++index) {
+                    gcData.push(gcs[index]);
+                }
+
+                for (var index = 0; index < gcs?.length; ++index) {
+                    const allocDataForGc = gcs[index].allocData;
+
+                    for (var innerIndex = 0; innerIndex < allocDataForGc.length; ++innerIndex) {
+                        allocations.push(allocDataForGc[innerIndex]);
+                    }
+                }
+            }
+
+            // At this point we will serialize the gc information and write to 
+            // disk.
+            if (!fs.existsSync(this.insights.gcDataSaveLocation)) {
+                vscode.window.showWarningMessage("GC stats location does not exist, please check the settings configuration for a valid path.");
+                return;
+            }
+
+            fs.readdir(this.insights.gcDataSaveLocation, (err, files) => {
+                // Calculate the save file name.
+                var fileName = document.processId.toString();
+                if (processInfo != undefined) {
+                    fileName = processInfo?.processName + "_" + document.processId.toString();
+                }
+
+                for(var index = 0; index < files.length; ++index) {
+                    const file = files[index];
+                    if (file.indexOf(fileName) != -1) {
+                        // This process already exists we will want to attach
+                        // the date to better distinguish
+                        fileName = fileName + "_" + new Date().toUTCString();
+
+                        break;
+                    }
+                }
+
+                var dataToWrite = {
+                    "gcData": gcData,
+                    "allocations": allocations
+                };
+
+                const jsonString = JSON.stringify(dataToWrite);
+
+                fileName += ".gcinfo";
+
+                const fullPath = path.join(this.insights.gcDataSaveLocation, fileName);
+
+                fs.writeFile(fullPath, jsonString, (err) => {
+                    if (err != null) {
+                        vscode.window.showWarningMessage("Failed to write file: " + err.toString());
+                    }
+                    else {
+                        this.insights.outputChannel.appendLine(`${fullPath} written to disk`);
+                    }
+                });
+            });
+        });
+
+        return promise;
+    }
+
+    saveCustomDocumentAs(document: vscode.CustomDocument, destination: vscode.Uri, cancellation: vscode.CancellationToken): Thenable<void> {
+        throw new Error('Method not implemented.');
+    }
+}
 
 class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextDocument {
     uri: vscode.Uri;
@@ -424,6 +511,7 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
     eol: vscode.EndOfLine;
     lineCount: number;
     processId: number;
+    listener: GcListener
 
     constructor(
         uri: vscode.Uri,
@@ -435,7 +523,8 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
         isClosed: boolean,
         eol: vscode.EndOfLine,
         lineCount: number,
-        processId: number
+        processId: number,
+        listener: GcListener,
     ) {
         super(() => {
             console.log("Tearing down ILDasmDocument");
@@ -451,6 +540,7 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
         this.eol = eol,
         this.lineCount = lineCount;
         this.processId = processId;
+        this.listener = listener;
     }
 
     lineAt(position: any): vscode.TextLine {
@@ -490,5 +580,33 @@ class DotnetInsightsGcDocument extends vscode.Disposable implements vscode.TextD
     
     validatePosition(position: vscode.Position): vscode.Position {
         throw new Error('Method not implemented.');
+    }
+
+    saveCustomDocument(document: DotnetInsightsGcDocument, cancellation: any): Thenable<void>
+    {
+        var promise = new Promise<void>((resolve, reject) => {
+            const processInfo: ProcessInfo | undefined = this.listener.processes.get(document.processId);
+            const gcs: GcData[] | undefined = processInfo?.data;
+            const allocations: AllocData[] | undefined = [];
+
+            var gcData = [] as GcData[];
+            if (gcs != undefined) {
+                for (var index = 0; index < gcs?.length; ++index) {
+                    gcData.push(gcs[index]);
+                }
+
+                for (var index = 0; index < gcs?.length; ++index) {
+                    const allocDataForGc = gcs[index].allocData;
+
+                    for (var innerIndex = 0; innerIndex < allocDataForGc.length; ++innerIndex) {
+                        allocations.push(allocDataForGc[innerIndex]);
+                    }
+                }
+            }
+
+            var i = 0;
+        });
+
+        return promise;
     }
 }

--- a/dotnetInsights/src/DotnetInsightsGcSnapshotEditor.ts
+++ b/dotnetInsights/src/DotnetInsightsGcSnapshotEditor.ts
@@ -1,0 +1,165 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { DotnetInsights } from "./dotnetInsights";
+import { GcListener, ProcessInfo, GcData, AllocData } from "./GcListener";
+
+import { DotnetInsightsGcDocument } from "./DotnetInsightsGcEditor";
+
+export class DotnetInsightsGcSnapshotEditor implements vscode.CustomReadonlyEditorProvider {
+    public static register(context: vscode.ExtensionContext, insights: DotnetInsights): vscode.Disposable {
+        const provider = new DotnetInsightsGcSnapshotEditor(context, insights, null);
+        const providerRegistration = vscode.window.registerCustomEditorProvider(DotnetInsightsGcSnapshotEditor.viewType, provider);
+        return providerRegistration;
+    }
+
+    public static readonly viewType = 'dotnetInsightsGcSnapshot.edit';
+
+    private timeInGc: number;
+    private allocData: AllocData[] | undefined;
+    
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly insights: DotnetInsights,
+        private gcData: any
+    ) {
+        this.timeInGc = 0;
+        this.allocData = undefined;
+    }
+
+    openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext, token: vscode.CancellationToken): vscode.CustomDocument | Thenable<vscode.CustomDocument> {
+        var filename = path.basename(uri.path);
+        var endofLine = os.platform() == "win32" ? vscode.EndOfLine.CRLF : vscode.EndOfLine.LF;
+
+        var processId = parseInt(filename.split(".gcstats")[0]);
+
+        var document = new DotnetInsightsGcDocument(uri,
+                                                    filename,
+                                                    false,
+                                                    "ildasm",
+                                                    1,
+                                                    false,
+                                                    true,
+                                                    endofLine,
+                                                    0,
+                                                    processId,
+                                                    null);
+
+        return document;
+    }
+
+    resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken): void | Thenable<void> {
+        webviewPanel.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [
+                vscode.Uri.joinPath(this.context.extensionUri, 'node_modules', 'chart.js', 'dist'),
+                vscode.Uri.joinPath(this.context.extensionUri, 'media')
+            ]
+        }
+
+        var gcDocument = document as DotnetInsightsGcDocument;
+        const pid = gcDocument.processId;
+
+        var gcEditor = this;
+
+        function updateWebview() {
+            // There are no updates possible for this view type.
+        }
+
+        webviewPanel.webview.html = this.getHtmlForWebview(gcDocument, webviewPanel.webview);
+    }
+
+    private getHtmlForWebview(document: DotnetInsightsGcDocument, webview: vscode.Webview): string {
+        const fileContents = fs.readFileSync(document.uri.fsPath);
+
+        const defaultHtmlReturn = /* html */`
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <!--
+            Use a content security policy to only allow loading images from https or from our extension directory,
+            and only allow scripts that have a specific nonce.
+            -->
+            
+            <meta http-equiv="Content-Security-Policy" 
+            content="default-src * vscode-resource: https: 'unsafe-inline' 'unsafe-eval';
+            script-src vscode-webview-resource: https: 'unsafe-inline' 'unsafe-eval';
+            style-src vscode-webview-resource: https: 'unsafe-inline';
+            img-src vscode-resource: https:;
+            connect-src vscode-resource: https: http:;">
+
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        </head>
+        <body>
+            
+        </body>
+        </html>`;
+
+        var gcData = null;
+
+        // We should have the json representation of the gc stats
+        try
+        {
+            gcData = JSON.parse(fileContents.toString());
+
+            if (gcData["allocations"] == null || gcData["gcData"] == null) {
+                throw new Error("Json error.");
+            }
+        }
+        catch(e) {
+            vscode.window.showWarningMessage(`${document.uri.fsPath} is corrupted or a incorrect type.`);
+            return defaultHtmlReturn;
+        }
+
+        // gc data has all of the allocations and gc events that occurred in the
+        // window. We will now go through and calculate the interesting data we
+        // want from what we were provided.
+
+        const gcs = gcData["gcData"];
+
+        // Time in GC.
+        var totalTimeInGc: number = 0.0;
+        var timesInEachGc = [];
+        var averageTimeInGc = 0;
+        var medianTimeInGc = 0;
+        var highestTimeInGc = 0;
+        var lowestTimeInGc = 0;
+        for (var index = 0; index < gcs.length; ++index) {
+            timesInEachGc.push(parseFloat(gcs[index]["data"]["PauseDurationMSec"]));
+        }
+
+        // Gcs over 50ms
+        var expensiveGcs = [];
+        for (var index = 0; index < gcs.length; ++index) {
+            if (parseFloat(gcs[index]["data"]["PauseDurationMSec"]) > 50) {
+                expensiveGcs.push(gcs[index]["data"]);
+            }
+        }
+
+        lowestTimeInGc = timesInEachGc[0];
+        for (var index = 0; index < timesInEachGc.length; ++index) {
+            totalTimeInGc += timesInEachGc[index];
+
+            if (timesInEachGc[index] < lowestTimeInGc) {
+                lowestTimeInGc = timesInEachGc[index];
+            }
+
+            if (timesInEachGc[index] > highestTimeInGc) {
+                highestTimeInGc = timesInEachGc[index];
+            }
+        }
+
+        timesInEachGc.sort();
+        var half = Math.floor(timesInEachGc.length / 2);
+        medianTimeInGc = timesInEachGc[half];
+
+        averageTimeInGc = totalTimeInGc / timesInEachGc.length;
+
+        // Allocations
+
+        return defaultHtmlReturn;
+    }
+}

--- a/dotnetInsights/src/dotnetInsights.ts
+++ b/dotnetInsights/src/dotnetInsights.ts
@@ -285,6 +285,8 @@ export class DotnetInsights {
 
     public onSaveIlDasm: OnSaveIlDasm | undefined;
 
+    public gcDataSaveLocation: string;
+
     constructor(outputChannel: vscode.OutputChannel) {
         this.ilDasmPath = "";
         this.ilDasmVersion = "";
@@ -338,6 +340,8 @@ export class DotnetInsights {
 
         this.listenerSetup = false;
         this.listeningToAllSaveEvents = false;
+
+        this.gcDataSaveLocation = "";
     }
 
     public setUseIldasm() {

--- a/dotnetInsights/src/extension.ts
+++ b/dotnetInsights/src/extension.ts
@@ -17,6 +17,7 @@ import { DotnetInsightsTreeDataProvider, Dependency, DotnetInsights } from './do
 import { DotnetInsightsTextEditorProvider } from "./DotnetInightsTextEditor";
 import { DotnetInsightsGcTreeDataProvider, GcDependency } from "./dotnetInsightsGc";
 import { DotnetInsightsGcEditor } from "./DotnetInsightsGcEditor";
+import { DotnetInsightsGcSnapshotEditor } from "./DotnetInsightsGcSnapshotEditor";
 import { DependencySetup } from "./DependencySetup";
 
 import { GcListener } from "./GcListener";
@@ -752,6 +753,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         context.subscriptions.push(DotnetInsightsTextEditorProvider.register(context, insights));
         context.subscriptions.push(DotnetInsightsGcEditor.register(context, insights, listener));
+        context.subscriptions.push(DotnetInsightsGcSnapshotEditor.register(context, insights));
 
         if (startupCallback != undefined) {
             startupCallback();

--- a/dotnetInsights/src/onSaveIlDasm.ts
+++ b/dotnetInsights/src/onSaveIlDasm.ts
@@ -15,7 +15,6 @@ import { ILDasmParser } from "./ilDamParser";
 import { JitOrder } from "./JitOrder";
 import { PmiCommand } from "./PmiCommand";
 import { ILDasm } from './IlDasm';
-import { throws } from 'node:assert';
 
 export class OnSaveIlDasm {
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This allows saving .gcstats files. Currently they will just dump the json data into a .gcinfo file.