### PR TITLE
Create an option to show the jitdump when viewing an asm file.

### DIFF
--- a/dotnetInsights/package.json
+++ b/dotnetInsights/package.json
@@ -3,7 +3,7 @@
   "displayName": ".NET Insights",
   "publisher": "jashoo",
   "description": "Monitor .NET Processes for GC information in real time, or drill into .NET DLLs by viewing the IL and compiled code. Relies on ildasm and a public .NET JIT tool PMI.",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "preview": false,
   "icon": "media/dep.png",
   "repository": {
@@ -213,6 +213,14 @@
         "title": "Show IL/Asm on save"
       },
       {
+        "command": "dotnetInsights.showJitDump",
+        "title": "Show jitdump for asm"
+      },
+      {
+        "command": "dotnetInsights.showAsm",
+        "title": "Show asm for Jit Dump"
+      },
+      {
         "command": "dotnetInsights.stopShowIlOnSave",
         "title": "Stop generating IL/Asm on save"
       },
@@ -226,6 +234,16 @@
         {
           "command": "dotnetInsights.realtimeIL",
           "when": "editorTextFocus && editorLangId == csharp",
+          "group": "dotnetInsightsGroup"
+        },
+        {
+          "command": "dotnetInsights.showJitDump",
+          "when": "editorTextFocus && editorLangId == asm",
+          "group": "dotnetInsightsGroup"
+        },
+        {
+          "command": "dotnetInsights.showAsm",
+          "when": "editorTextFocus && editorLangId == jitdump",
           "group": "dotnetInsightsGroup"
         }
       ],

--- a/dotnetInsights/src/PmiCommand.ts
+++ b/dotnetInsights/src/PmiCommand.ts
@@ -62,7 +62,7 @@ export class PmiCommand {
             "COMPlus_TC_QuickJit": "0"
         }
 
-        if (methodName != undefined) {
+        if (methodName != undefined && (extraOptions == undefined || extraOptions == null)) {
             extraOptions = {
                 "COMPlus_JitDisasm": `${methodName}`,
                 "COMPlus_JitGCDump": `${methodName}`

--- a/dotnetInsights/src/extension.ts
+++ b/dotnetInsights/src/extension.ts
@@ -9,10 +9,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as os from "os";
 
-import * as request from 'request';
-import * as targz from "targz";
-import * as rimraf from "rimraf";
-
 import { DotnetInsightsTreeDataProvider, Dependency, DotnetInsights } from './dotnetInsights';
 import { DotnetInsightsTextEditorProvider } from "./DotnetInightsTextEditor";
 import { DotnetInsightsGcTreeDataProvider, GcDependency } from "./dotnetInsightsGc";
@@ -647,6 +643,70 @@ export function activate(context: vscode.ExtensionContext) {
         });
 
         context.subscriptions.push(stopShowIlOnSave);
+
+        vscode.commands.registerCommand("dotnetInsights.showJitDump", () => {
+            var activeFile  = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+            if (activeFile == undefined) {
+                return;
+            }
+
+            console.log(path.extname(activeFile) == ".asm");
+
+            // We have an asm file active, we have generated the jitdump side by
+            // side, just display that file
+
+            const visibleEditors = vscode.window.visibleTextEditors;
+            var index = 0;
+
+            for (index = 0; index < visibleEditors.length; ++index) {
+                if (visibleEditors[index].document.uri.fsPath == activeFile) {
+                    break;
+                }
+            }
+
+            const jitDumpFile = activeFile?.replace(".asm", ".jitDump");
+
+            if (!fs.existsSync(jitDumpFile)) {
+                return;
+            }
+
+            vscode.workspace.openTextDocument(jitDumpFile).then(doc => {
+                vscode.window.showTextDocument(doc, index);
+            });
+        });
+
+        vscode.commands.registerCommand("dotnetInsights.showAsm", () => {
+            var activeFile  = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+            if (activeFile == undefined) {
+                return;
+            }
+
+            console.log(path.extname(activeFile) == ".jitdump" || path.extname(activeFile) == ".jitDump");
+
+            // We have an asm file active, we have generated the jitdump side by
+            // side, just display that file
+
+            const visibleEditors = vscode.window.visibleTextEditors;
+            var index = 0;
+
+            for (index = 0; index < visibleEditors.length; ++index) {
+                if (visibleEditors[index].document.uri.fsPath == activeFile) {
+                    break;
+                }
+            }
+
+            const asmFile = activeFile?.replace(".jitDump", ".asm");
+
+            if (!fs.existsSync(asmFile)) {
+                return;
+            }
+
+            vscode.workspace.openTextDocument(asmFile).then(doc => {
+                vscode.window.showTextDocument(doc, index);
+            });
+        });
 
         vscode.commands.registerCommand("dotnetInsights.realtimeIL", (reWriteFile?: boolean) => {
             // We have been asked to show realtime asm of the current file.


### PR DESCRIPTION
This is currently only expected to work when we generate the
asm on save. However, there will be work to jitdump when disasm
a particular method.