### PR TITLE
Align stack pointer for AARCH

### DIFF
--- a/profiler/native/CMakeLists.txt
+++ b/profiler/native/CMakeLists.txt
@@ -34,7 +34,11 @@ if (WIN32)
     FILE(GLOB asm_sources asm/amd64/windows/*.asm)
     set(def_sources ${PROJECT_SOURCE_DIR}/ev31_profiler.def)
 else()
-    FILE(GLOB asm_sources asm/amd64/unix/*.S)
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
+        FILE(GLOB asm_sources asm/amd64/unix/*.S)
+    else ()
+        FILE(GLOB asm_sources asm/aarch64/unix/*.S)
+    endif()
 endif()
 
 # Create the executable

--- a/profiler/native/asm/aarch64/unix/asm_helper.S
+++ b/profiler/native/asm/aarch64/unix/asm_helper.S
@@ -5,202 +5,110 @@
 .globl _TailcallWrapper
 
 _EnterWrapper:
-
-    str   x0, [sp, #-8]!         
-    str   x1, [sp, #-8]!         
-    str   x2, [sp, #-8]!         
-    str   x3, [sp, #-8]!         
-    str   x4, [sp, #-8]!         
-    str   x5, [sp, #-8]!         
-    str   x6, [sp, #-8]!         
-    str   x7, [sp, #-8]!         
-    str   x8, [sp, #-8]!         
-    str   x9, [sp, #-8]!         
-    str   x10, [sp, #-8]!         
-    str   x11, [sp, #-8]!         
-    str   x12, [sp, #-8]!         
-    str   x13, [sp, #-8]!         
-    str   x14, [sp, #-8]!         
-    str   x15, [sp, #-8]!         
-    str   x16, [sp, #-8]!         
-    str   x17, [sp, #-8]!         
-    str   x18, [sp, #-8]!         
-    str   x19, [sp, #-8]!         
-    str   x20, [sp, #-8]!         
-    str   x21, [sp, #-8]!         
-    str   x22, [sp, #-8]!         
-    str   x23, [sp, #-8]!         
-    str   x24, [sp, #-8]!         
-    str   x25, [sp, #-8]!         
-    str   x26, [sp, #-8]!         
-    str   x27, [sp, #-8]!         
-    str   x28, [sp, #-8]!         
-    str   x29, [sp, #-8]!         
-    str   x30, [sp, #-8]!         
+    stp     x0, x1, [sp, #-0xF0]
+    stp     x2, x3, [sp, #-0xE0]
+    stp     x4, x5, [sp, #-0xD0]
+    stp     x6, x7, [sp, #-0xC0]
+    stp     x8, x9, [sp, #-0xB0]
+    stp     x10, x11, [sp, #-0xA0]
+    stp     x12, x13, [sp, #-0x90]
+    stp     x14, x15, [sp, #-0x80]
+    stp     x16, x17, [sp, #-0x70]
+    stp     x18, x19, [sp, #-0x60]
+    stp     x20, x21, [sp, #-0x50]
+    stp     x22, x23, [sp, #-0x40]
+    stp     x24, x25, [sp, #-0x30]
+    stp     x26, x27, [sp, #-0x20]
+    stp     x28, x0, [sp, #-0x10]
 
     b _EnterStub
-    ldr   x0, [sp], #8           
-    ldr   x1, [sp], #8           
-    ldr   x2, [sp], #8           
-    ldr   x3, [sp], #8           
-    ldr   x4, [sp], #8           
-    ldr   x5, [sp], #8           
-    ldr   x6, [sp], #8           
-    ldr   x7, [sp], #8           
-    ldr   x8, [sp], #8           
-    ldr   x9, [sp], #8           
-    ldr   x10, [sp], #8           
-    ldr   x11, [sp], #8           
-    ldr   x12, [sp], #8           
-    ldr   x13, [sp], #8           
-    ldr   x14, [sp], #8           
-    ldr   x15, [sp], #8           
-    ldr   x16, [sp], #8           
-    ldr   x17, [sp], #8           
-    ldr   x18, [sp], #8           
-    ldr   x19, [sp], #8           
-    ldr   x20, [sp], #8           
-    ldr   x21, [sp], #8           
-    ldr   x22, [sp], #8           
-    ldr   x23, [sp], #8           
-    ldr   x24, [sp], #8           
-    ldr   x25, [sp], #8           
-    ldr   x26, [sp], #8           
-    ldr   x27, [sp], #8           
-    ldr   x28, [sp], #8           
-    ldr   x29, [sp], #8           
-    ldr   x30, [sp], #8           
+    
+    ldp     x0, x1, [sp, #-0xF0]
+    ldp     x2, x3, [sp, #-0xE0]
+    ldp     x4, x5, [sp, #-0xD0]
+    ldp     x6, x7, [sp, #-0xC0]
+    ldp     x8, x9, [sp, #-0xB0]
+    ldp     x10, x11, [sp, #-0xA0]
+    ldp     x12, x13, [sp, #-0x90]
+    ldp     x14, x15, [sp, #-0x80]
+    ldp     x16, x17, [sp, #-0x70]
+    ldp     x18, x19, [sp, #-0x60]
+    ldp     x20, x21, [sp, #-0x50]
+    ldp     x22, x23, [sp, #-0x40]
+    ldp     x24, x25, [sp, #-0x30]
+    ldp     x26, x27, [sp, #-0x20]
+    ldp     x28, x0, [sp, #-0x10]
+
     ret
 
 _ExitWrapper:
-    str   x0, [sp, #-8]!         
-    str   x1, [sp, #-8]!         
-    str   x2, [sp, #-8]!         
-    str   x3, [sp, #-8]!         
-    str   x4, [sp, #-8]!         
-    str   x5, [sp, #-8]!         
-    str   x6, [sp, #-8]!         
-    str   x7, [sp, #-8]!         
-    str   x8, [sp, #-8]!         
-    str   x9, [sp, #-8]!         
-    str   x10, [sp, #-8]!         
-    str   x11, [sp, #-8]!         
-    str   x12, [sp, #-8]!         
-    str   x13, [sp, #-8]!         
-    str   x14, [sp, #-8]!         
-    str   x15, [sp, #-8]!         
-    str   x16, [sp, #-8]!         
-    str   x17, [sp, #-8]!         
-    str   x18, [sp, #-8]!         
-    str   x19, [sp, #-8]!         
-    str   x20, [sp, #-8]!         
-    str   x21, [sp, #-8]!         
-    str   x22, [sp, #-8]!         
-    str   x23, [sp, #-8]!         
-    str   x24, [sp, #-8]!         
-    str   x25, [sp, #-8]!         
-    str   x26, [sp, #-8]!         
-    str   x27, [sp, #-8]!         
-    str   x28, [sp, #-8]!         
-    str   x29, [sp, #-8]!         
-    str   x30, [sp, #-8]!
+
+    stp     x0, x1, [sp, #-0xF0]
+    stp     x2, x3, [sp, #-0xE0]
+    stp     x4, x5, [sp, #-0xD0]
+    stp     x6, x7, [sp, #-0xC0]
+    stp     x8, x9, [sp, #-0xB0]
+    stp     x10, x11, [sp, #-0xA0]
+    stp     x12, x13, [sp, #-0x90]
+    stp     x14, x15, [sp, #-0x80]
+    stp     x16, x17, [sp, #-0x70]
+    stp     x18, x19, [sp, #-0x60]
+    stp     x20, x21, [sp, #-0x50]
+    stp     x22, x23, [sp, #-0x40]
+    stp     x24, x25, [sp, #-0x30]
+    stp     x26, x27, [sp, #-0x20]
+    stp     x28, x0, [sp, #-0x10]
+
     b _ExitStub
-    ldr   x0, [sp], #8           
-    ldr   x1, [sp], #8           
-    ldr   x2, [sp], #8           
-    ldr   x3, [sp], #8           
-    ldr   x4, [sp], #8           
-    ldr   x5, [sp], #8           
-    ldr   x6, [sp], #8           
-    ldr   x7, [sp], #8           
-    ldr   x8, [sp], #8           
-    ldr   x9, [sp], #8           
-    ldr   x10, [sp], #8           
-    ldr   x11, [sp], #8           
-    ldr   x12, [sp], #8           
-    ldr   x13, [sp], #8           
-    ldr   x14, [sp], #8           
-    ldr   x15, [sp], #8           
-    ldr   x16, [sp], #8           
-    ldr   x17, [sp], #8           
-    ldr   x18, [sp], #8           
-    ldr   x19, [sp], #8           
-    ldr   x20, [sp], #8           
-    ldr   x21, [sp], #8           
-    ldr   x22, [sp], #8           
-    ldr   x23, [sp], #8           
-    ldr   x24, [sp], #8           
-    ldr   x25, [sp], #8           
-    ldr   x26, [sp], #8           
-    ldr   x27, [sp], #8           
-    ldr   x28, [sp], #8           
-    ldr   x29, [sp], #8           
-    ldr   x30, [sp], #8
-    ret
+    
+    ldp     x0, x1, [sp, #-0xF0]
+    ldp     x2, x3, [sp, #-0xE0]
+    ldp     x4, x5, [sp, #-0xD0]
+    ldp     x6, x7, [sp, #-0xC0]
+    ldp     x8, x9, [sp, #-0xB0]
+    ldp     x10, x11, [sp, #-0xA0]
+    ldp     x12, x13, [sp, #-0x90]
+    ldp     x14, x15, [sp, #-0x80]
+    ldp     x16, x17, [sp, #-0x70]
+    ldp     x18, x19, [sp, #-0x60]
+    ldp     x20, x21, [sp, #-0x50]
+    ldp     x22, x23, [sp, #-0x40]
+    ldp     x24, x25, [sp, #-0x30]
+    ldp     x26, x27, [sp, #-0x20]
+    ldp     x28, x0, [sp, #-0x10]
 
 _TailcallWrapper:
 
-    str   x0, [sp, #-8]!         
-    str   x1, [sp, #-8]!         
-    str   x2, [sp, #-8]!         
-    str   x3, [sp, #-8]!         
-    str   x4, [sp, #-8]!         
-    str   x5, [sp, #-8]!         
-    str   x6, [sp, #-8]!         
-    str   x7, [sp, #-8]!         
-    str   x8, [sp, #-8]!         
-    str   x9, [sp, #-8]!         
-    str   x10, [sp, #-8]!         
-    str   x11, [sp, #-8]!         
-    str   x12, [sp, #-8]!         
-    str   x13, [sp, #-8]!         
-    str   x14, [sp, #-8]!         
-    str   x15, [sp, #-8]!         
-    str   x16, [sp, #-8]!         
-    str   x17, [sp, #-8]!         
-    str   x18, [sp, #-8]!         
-    str   x19, [sp, #-8]!         
-    str   x20, [sp, #-8]!         
-    str   x21, [sp, #-8]!         
-    str   x22, [sp, #-8]!         
-    str   x23, [sp, #-8]!         
-    str   x24, [sp, #-8]!         
-    str   x25, [sp, #-8]!         
-    str   x26, [sp, #-8]!         
-    str   x27, [sp, #-8]!         
-    str   x28, [sp, #-8]!         
-    str   x29, [sp, #-8]!         
-    str   x30, [sp, #-8]!
+    stp     x0, x1, [sp, #-0xF0]
+    stp     x2, x3, [sp, #-0xE0]
+    stp     x4, x5, [sp, #-0xD0]
+    stp     x6, x7, [sp, #-0xC0]
+    stp     x8, x9, [sp, #-0xB0]
+    stp     x10, x11, [sp, #-0xA0]
+    stp     x12, x13, [sp, #-0x90]
+    stp     x14, x15, [sp, #-0x80]
+    stp     x16, x17, [sp, #-0x70]
+    stp     x18, x19, [sp, #-0x60]
+    stp     x20, x21, [sp, #-0x50]
+    stp     x22, x23, [sp, #-0x40]
+    stp     x24, x25, [sp, #-0x30]
+    stp     x26, x27, [sp, #-0x20]
+    stp     x28, x0, [sp, #-0x10]
+
     b _TailcallStub
-    ldr   x0, [sp], #8           
-    ldr   x1, [sp], #8           
-    ldr   x2, [sp], #8           
-    ldr   x3, [sp], #8           
-    ldr   x4, [sp], #8           
-    ldr   x5, [sp], #8           
-    ldr   x6, [sp], #8           
-    ldr   x7, [sp], #8           
-    ldr   x8, [sp], #8           
-    ldr   x9, [sp], #8           
-    ldr   x10, [sp], #8           
-    ldr   x11, [sp], #8           
-    ldr   x12, [sp], #8           
-    ldr   x13, [sp], #8           
-    ldr   x14, [sp], #8           
-    ldr   x15, [sp], #8           
-    ldr   x16, [sp], #8           
-    ldr   x17, [sp], #8           
-    ldr   x18, [sp], #8           
-    ldr   x19, [sp], #8           
-    ldr   x20, [sp], #8           
-    ldr   x21, [sp], #8           
-    ldr   x22, [sp], #8           
-    ldr   x23, [sp], #8           
-    ldr   x24, [sp], #8           
-    ldr   x25, [sp], #8           
-    ldr   x26, [sp], #8           
-    ldr   x27, [sp], #8           
-    ldr   x28, [sp], #8           
-    ldr   x29, [sp], #8           
-    ldr   x30, [sp], #8
-    ret
+    
+    ldp     x0, x1, [sp, #-0xF0]
+    ldp     x2, x3, [sp, #-0xE0]
+    ldp     x4, x5, [sp, #-0xD0]
+    ldp     x6, x7, [sp, #-0xC0]
+    ldp     x8, x9, [sp, #-0xB0]
+    ldp     x10, x11, [sp, #-0xA0]
+    ldp     x12, x13, [sp, #-0x90]
+    ldp     x14, x15, [sp, #-0x80]
+    ldp     x16, x17, [sp, #-0x70]
+    ldp     x18, x19, [sp, #-0x60]
+    ldp     x20, x21, [sp, #-0x50]
+    ldp     x22, x23, [sp, #-0x40]
+    ldp     x24, x25, [sp, #-0x30]
+    ldp     x26, x27, [sp, #-0x20]
+    ldp     x28, x0, [sp, #-0x10]

--- a/profiler/native/asm/aarch64/unix/asm_helper.S
+++ b/profiler/native/asm/aarch64/unix/asm_helper.S
@@ -1,0 +1,206 @@
+.section __TEXT,__text
+
+.globl _EnterWrapper
+.globl _ExitWrapper
+.globl _TailcallWrapper
+
+_EnterWrapper:
+
+    str   x0, [sp, #-8]!         
+    str   x1, [sp, #-8]!         
+    str   x2, [sp, #-8]!         
+    str   x3, [sp, #-8]!         
+    str   x4, [sp, #-8]!         
+    str   x5, [sp, #-8]!         
+    str   x6, [sp, #-8]!         
+    str   x7, [sp, #-8]!         
+    str   x8, [sp, #-8]!         
+    str   x9, [sp, #-8]!         
+    str   x10, [sp, #-8]!         
+    str   x11, [sp, #-8]!         
+    str   x12, [sp, #-8]!         
+    str   x13, [sp, #-8]!         
+    str   x14, [sp, #-8]!         
+    str   x15, [sp, #-8]!         
+    str   x16, [sp, #-8]!         
+    str   x17, [sp, #-8]!         
+    str   x18, [sp, #-8]!         
+    str   x19, [sp, #-8]!         
+    str   x20, [sp, #-8]!         
+    str   x21, [sp, #-8]!         
+    str   x22, [sp, #-8]!         
+    str   x23, [sp, #-8]!         
+    str   x24, [sp, #-8]!         
+    str   x25, [sp, #-8]!         
+    str   x26, [sp, #-8]!         
+    str   x27, [sp, #-8]!         
+    str   x28, [sp, #-8]!         
+    str   x29, [sp, #-8]!         
+    str   x30, [sp, #-8]!         
+
+    b _EnterStub
+    ldr   x0, [sp], #8           
+    ldr   x1, [sp], #8           
+    ldr   x2, [sp], #8           
+    ldr   x3, [sp], #8           
+    ldr   x4, [sp], #8           
+    ldr   x5, [sp], #8           
+    ldr   x6, [sp], #8           
+    ldr   x7, [sp], #8           
+    ldr   x8, [sp], #8           
+    ldr   x9, [sp], #8           
+    ldr   x10, [sp], #8           
+    ldr   x11, [sp], #8           
+    ldr   x12, [sp], #8           
+    ldr   x13, [sp], #8           
+    ldr   x14, [sp], #8           
+    ldr   x15, [sp], #8           
+    ldr   x16, [sp], #8           
+    ldr   x17, [sp], #8           
+    ldr   x18, [sp], #8           
+    ldr   x19, [sp], #8           
+    ldr   x20, [sp], #8           
+    ldr   x21, [sp], #8           
+    ldr   x22, [sp], #8           
+    ldr   x23, [sp], #8           
+    ldr   x24, [sp], #8           
+    ldr   x25, [sp], #8           
+    ldr   x26, [sp], #8           
+    ldr   x27, [sp], #8           
+    ldr   x28, [sp], #8           
+    ldr   x29, [sp], #8           
+    ldr   x30, [sp], #8           
+    ret
+
+_ExitWrapper:
+    str   x0, [sp, #-8]!         
+    str   x1, [sp, #-8]!         
+    str   x2, [sp, #-8]!         
+    str   x3, [sp, #-8]!         
+    str   x4, [sp, #-8]!         
+    str   x5, [sp, #-8]!         
+    str   x6, [sp, #-8]!         
+    str   x7, [sp, #-8]!         
+    str   x8, [sp, #-8]!         
+    str   x9, [sp, #-8]!         
+    str   x10, [sp, #-8]!         
+    str   x11, [sp, #-8]!         
+    str   x12, [sp, #-8]!         
+    str   x13, [sp, #-8]!         
+    str   x14, [sp, #-8]!         
+    str   x15, [sp, #-8]!         
+    str   x16, [sp, #-8]!         
+    str   x17, [sp, #-8]!         
+    str   x18, [sp, #-8]!         
+    str   x19, [sp, #-8]!         
+    str   x20, [sp, #-8]!         
+    str   x21, [sp, #-8]!         
+    str   x22, [sp, #-8]!         
+    str   x23, [sp, #-8]!         
+    str   x24, [sp, #-8]!         
+    str   x25, [sp, #-8]!         
+    str   x26, [sp, #-8]!         
+    str   x27, [sp, #-8]!         
+    str   x28, [sp, #-8]!         
+    str   x29, [sp, #-8]!         
+    str   x30, [sp, #-8]!
+    b _ExitStub
+    ldr   x0, [sp], #8           
+    ldr   x1, [sp], #8           
+    ldr   x2, [sp], #8           
+    ldr   x3, [sp], #8           
+    ldr   x4, [sp], #8           
+    ldr   x5, [sp], #8           
+    ldr   x6, [sp], #8           
+    ldr   x7, [sp], #8           
+    ldr   x8, [sp], #8           
+    ldr   x9, [sp], #8           
+    ldr   x10, [sp], #8           
+    ldr   x11, [sp], #8           
+    ldr   x12, [sp], #8           
+    ldr   x13, [sp], #8           
+    ldr   x14, [sp], #8           
+    ldr   x15, [sp], #8           
+    ldr   x16, [sp], #8           
+    ldr   x17, [sp], #8           
+    ldr   x18, [sp], #8           
+    ldr   x19, [sp], #8           
+    ldr   x20, [sp], #8           
+    ldr   x21, [sp], #8           
+    ldr   x22, [sp], #8           
+    ldr   x23, [sp], #8           
+    ldr   x24, [sp], #8           
+    ldr   x25, [sp], #8           
+    ldr   x26, [sp], #8           
+    ldr   x27, [sp], #8           
+    ldr   x28, [sp], #8           
+    ldr   x29, [sp], #8           
+    ldr   x30, [sp], #8
+    ret
+
+_TailcallWrapper:
+
+    str   x0, [sp, #-8]!         
+    str   x1, [sp, #-8]!         
+    str   x2, [sp, #-8]!         
+    str   x3, [sp, #-8]!         
+    str   x4, [sp, #-8]!         
+    str   x5, [sp, #-8]!         
+    str   x6, [sp, #-8]!         
+    str   x7, [sp, #-8]!         
+    str   x8, [sp, #-8]!         
+    str   x9, [sp, #-8]!         
+    str   x10, [sp, #-8]!         
+    str   x11, [sp, #-8]!         
+    str   x12, [sp, #-8]!         
+    str   x13, [sp, #-8]!         
+    str   x14, [sp, #-8]!         
+    str   x15, [sp, #-8]!         
+    str   x16, [sp, #-8]!         
+    str   x17, [sp, #-8]!         
+    str   x18, [sp, #-8]!         
+    str   x19, [sp, #-8]!         
+    str   x20, [sp, #-8]!         
+    str   x21, [sp, #-8]!         
+    str   x22, [sp, #-8]!         
+    str   x23, [sp, #-8]!         
+    str   x24, [sp, #-8]!         
+    str   x25, [sp, #-8]!         
+    str   x26, [sp, #-8]!         
+    str   x27, [sp, #-8]!         
+    str   x28, [sp, #-8]!         
+    str   x29, [sp, #-8]!         
+    str   x30, [sp, #-8]!
+    b _TailcallStub
+    ldr   x0, [sp], #8           
+    ldr   x1, [sp], #8           
+    ldr   x2, [sp], #8           
+    ldr   x3, [sp], #8           
+    ldr   x4, [sp], #8           
+    ldr   x5, [sp], #8           
+    ldr   x6, [sp], #8           
+    ldr   x7, [sp], #8           
+    ldr   x8, [sp], #8           
+    ldr   x9, [sp], #8           
+    ldr   x10, [sp], #8           
+    ldr   x11, [sp], #8           
+    ldr   x12, [sp], #8           
+    ldr   x13, [sp], #8           
+    ldr   x14, [sp], #8           
+    ldr   x15, [sp], #8           
+    ldr   x16, [sp], #8           
+    ldr   x17, [sp], #8           
+    ldr   x18, [sp], #8           
+    ldr   x19, [sp], #8           
+    ldr   x20, [sp], #8           
+    ldr   x21, [sp], #8           
+    ldr   x22, [sp], #8           
+    ldr   x23, [sp], #8           
+    ldr   x24, [sp], #8           
+    ldr   x25, [sp], #8           
+    ldr   x26, [sp], #8           
+    ldr   x27, [sp], #8           
+    ldr   x28, [sp], #8           
+    ldr   x29, [sp], #8           
+    ldr   x30, [sp], #8
+    ret


### PR DESCRIPTION
Previously the SP was not 16 byte aligned after saving all the registers. This PR changes that.